### PR TITLE
use new setManualVizPoseUpdateEnabled() plugin feature

### DIFF
--- a/viz/PCLPointCloudVisualization.cpp
+++ b/viz/PCLPointCloudVisualization.cpp
@@ -19,7 +19,7 @@ struct PCLPointCloudVisualization::Data {
 
 
 PCLPointCloudVisualization::PCLPointCloudVisualization()
-    : p(new Data), default_feature_color(osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f)), show_color(true), show_intensity(false)
+    : p(new Data), default_feature_color(osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f)), show_color(true), show_intensity(false), updateDataFramePosition(false)
 {
 }
 
@@ -65,6 +65,10 @@ void PCLPointCloudVisualization::updateMainNode ( osg::Node* node )
 
 void PCLPointCloudVisualization::updateDataIntern(pcl::PCLPointCloud2 const& value)
 {
+    if (updateDataFramePosition)
+    {
+        updateManualVizPose();
+    }
     p->data = value;
 }
 

--- a/viz/PCLPointCloudVisualization.hpp
+++ b/viz/PCLPointCloudVisualization.hpp
@@ -18,6 +18,7 @@ namespace vizkit3d
     Q_PROPERTY(double pointSize READ getPointSize WRITE setPointSize)
     Q_PROPERTY(bool showColor READ getShowColor WRITE setShowColor)
     Q_PROPERTY(bool showIntensity READ getShowIntensity WRITE setShowIntensity)
+    Q_PROPERTY(bool updateFrameOnlyOnNewData READ getUpdateFramePositionOnlyOnNewData WRITE setUpdateFramePositionOnlyOnNewData)
 
     public slots:
         QColor getDefaultFeatureColor();
@@ -36,6 +37,15 @@ namespace vizkit3d
         Q_INVOKABLE void updateData(pcl::PCLPointCloud2 const &sample)
         {vizkit3d::Vizkit3DPlugin<pcl::PCLPointCloud2>::updateData(sample);}
 
+        bool getUpdateFramePositionOnlyOnNewData() {
+            return updateDataFramePosition;
+        }
+
+        void setUpdateFramePositionOnlyOnNewData(const bool &newvalue) {
+            updateDataFramePosition = newvalue;
+            setManualVizPoseUpdateEnabled(updateDataFramePosition);
+        }
+
     protected:
         virtual osg::ref_ptr<osg::Node> createMainNode();
         virtual void updateMainNode(osg::Node* node);
@@ -51,6 +61,7 @@ namespace vizkit3d
         osg::ref_ptr<osg::Vec4Array> color;
         bool show_color;
         bool show_intensity;
+        bool updateDataFramePosition;
     };
 }
 #endif


### PR DESCRIPTION
Merge after https://github.com/rock-core/gui-vizkit3d/pull/72

Implements new feature that moves the cloud in visualization only when new data arrives. Has to be enabled via property after frame is set.