### PR TITLE
Fix/pcl suffix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 # CMakeLists.txt has to be located in the project folder and cmake has to be
 # executed from 'project/build' with 'cmake ../'.
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
+project(vizkit3d_pcl VERSION 0.1)
+
 find_package(Rock)
-rock_init(vizkit3d_pcl 0.1)
+rock_init()
 rock_feature(NOCURDIR)
 rock_standard_layout()

--- a/viz/CMakeLists.txt
+++ b/viz/CMakeLists.txt
@@ -6,6 +6,9 @@ endif()
 rock_find_pkgconfig(Eigen3 eigen3 REQUIRED)
 add_definitions(-DEIGEN_USE_NEW_STDVECTOR)
 find_package(PCL 1.7 REQUIRED COMPONENTS common)
+IF("${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}" VERSION_LESS 1.14)
+    SET(PCL_VERSION_SUFFIX "-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}")
+ENDIF()
 
 # rock_vizkit_plugin(vizkit3d_pcl-viz
 #         PluginLoader.cpp
@@ -40,7 +43,7 @@ if (ROCK_QT_VERSION_4)
         ${SOURCES}
         HEADERS ${HEADERS}
         MOC ${MOC}
-        DEPS_PKGCONFIG eigen3 pcl_common-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}
+        DEPS_PKGCONFIG eigen3 pcl_common${PCL_VERSION_SUFFIX}
 )
 endif()
 
@@ -49,6 +52,6 @@ if (ROCK_QT_VERSION_5)
         ${SOURCES}
         HEADERS ${HEADERS}
         MOC5 ${MOC}
-        DEPS_PKGCONFIG eigen3 pcl_common-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}
+        DEPS_PKGCONFIG eigen3 pcl_common${PCL_VERSION_SUFFIX}
 )
 endif()

--- a/viz/PCLPointCloudVisualization.cpp
+++ b/viz/PCLPointCloudVisualization.cpp
@@ -19,7 +19,7 @@ struct PCLPointCloudVisualization::Data {
 
 
 PCLPointCloudVisualization::PCLPointCloudVisualization()
-    : p(new Data), default_feature_color(osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f)), show_color(true), show_intensity(false), useHeightColoring(false), updateDataFramePosition(false)
+    : p(new Data), default_feature_color(osg::Vec4f(1.0f, 1.0f, 1.0f, 1.0f)), show_color(true), show_intensity(false), updateDataFramePosition(false), useHeightColoring(false)
 {
 }
 


### PR DESCRIPTION
PCL dropped the version suffix from it's pkg-config file with version 1.14
Also fixed some warnings.